### PR TITLE
Launch failure report `java.lang.IllegalAccessError`

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,47 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "java",
+      "name": "runClient",
+      "request": "launch",
+      "mainClass": "cpw.mods.bootstraplauncher.BootstrapLauncher",
+      "projectName": "kaupenjoe.forge-course-118",
+      "cwd": "${workspaceFolder}\\run",
+      "vmArgs": "-Dforge.logging.console.level\u003ddebug -Dforge.logging.markers\u003dREGISTRIES -DlegacyClassPath.file\u003dC:\\Projects\\minecraft\\kaupenjoe.forge-course-118\\build\\classpath\\runClient_minecraftClasspath.txt -DignoreList\u003dbootstraplauncher,securejarhandler,asm-commons,asm-util,asm-analysis,asm-tree,asm,client-extra,fmlcore,javafmllanguage,mclanguage,forge- -DnativesDirectory\u003dC:\\Projects\\minecraft\\kaupenjoe.forge-course-118\\build\\natives -DmergeModules\u003djna-5.8.0.jar,jna-platform-58.0.jar,java-objc-bridge-1.0.0.jar -p C:\\Users\\lesma\\.gradle\\caches\\modules-2\\files-2.1\\cpw.mods\\bootstraplauncher\\0.1.17\\899fb8e3912bb7d14a6f9611de117f77db710ec3\\bootstraplauncher-0.1.17.jar;C:\\Users\\lesma\\.gradle\\caches\\modules-2\\files-2.1\\cpw.mods\\securejarhandler\\0.9.54\\24b670f2c026ec9777e64a2c2126ebc8635dbe8d\\securejarhandler-0.9.54.jar;C:\\Users\\lesma\\.gradle\\caches\\modules-2\\files-2.1\\org.ow2.asm\\asm-commons\\9.1\\8b971b182eb5cf100b9e8d4119152d83e00e0fdd\\asm-commons-9.1.jar;C:\\Users\\lesma\\.gradle\\caches\\modules-2\\files-2.1\\org.ow2.asm\\asm-util\\9.1\\36464a45d871779f3383a8a9aba2b26562a86729\\asm-util-9.1.jar;C:\\Users\\lesma\\.gradle\\caches\\modules-2\\files-2.1\\org.ow2.asm\\asm-analysis\\9.1\\4f61b83b81d8b659958f4bcc48907e93ecea55a0\\asm-analysis-9.1.jar;C:\\Users\\lesma\\.gradle\\caches\\modules-2\\files-2.1\\org.ow2.asm\\asm-tree\\9.1\\c333f2a855069cb8eb17a40a3eb8b1b67755d0eb\\asm-tree-9.1.jar;C:\\Users\\lesma\\.gradle\\caches\\modules-2\\files-2.1\\org.ow2.asm\\asm\\9.1\\a99500cf6eea30535eeac6be73899d048f8d12a8\\asm-9.1.jar --add-modules ALL-MODULE-PATH --add-opens java.base/java.util.jar\u003dcpw.mods.securejarhandler --add-exports java.base/sun.security.util\u003dcpw.mods.securejarhandler --add-exports jdk.naming.dns/com.sun.jndi.dns\u003djava.naming -XX:HeapDumpPath\u003dMojangTricksIntelDriversForPerformance_javaw.exe_minecraft.exe.heapdump \"-Dos.name\u003dWindows 10\" -Dos.version\u003d10.0",
+      "args": "--launchTarget forgeclientuserdev --version MOD_DEV --assetIndex 1.18 --assetsDir C:\\Users\\lesma\\.gradle\\caches\\forge_gradle\\assets --gameDir . --fml.forgeVersion 39.0.5 --fml.mcVersion 1.18.1 --fml.forgeGroup net.minecraftforge --fml.mcpVersion 20211210.034407",
+      "env": {
+        "MOD_CLASSES": "mccourse%%${workspaceFolder}\\bin\\main;mccourse%%${workspaceFolder}\\bin\\main",
+        "MCP_MAPPINGS": "parchment_2021.12.13-nightly-SNAPSHOT-1.18.1"
+      }
+    },
+    {
+      "type": "java",
+      "name": "runData",
+      "request": "launch",
+      "mainClass": "cpw.mods.bootstraplauncher.BootstrapLauncher",
+      "projectName": "kaupenjoe.forge-course-118",
+      "cwd": "${workspaceFolder}\\run",
+      "vmArgs": "-Dforge.logging.console.level\u003ddebug -Dforge.logging.markers\u003dREGISTRIES -DlegacyClassPath.file\u003dC:\\Projects\\minecraft\\kaupenjoe.forge-course-118\\build\\classpath\\runData_minecraftClasspath.txt -DignoreList\u003dbootstraplauncher,securejarhandler,asm-commons,asm-util,asm-analysis,asm-tree,asm,client-extra,fmlcore,javafmllanguage,mclanguage,forge- -DmergeModules\u003djna-5.8.0.jar,jna-platform-58.0.jar,java-objc-bridge-1.0.0.jar -p C:\\Users\\lesma\\.gradle\\caches\\modules-2\\files-2.1\\cpw.mods\\bootstraplauncher\\0.1.17\\899fb8e3912bb7d14a6f9611de117f77db710ec3\\bootstraplauncher-0.1.17.jar;C:\\Users\\lesma\\.gradle\\caches\\modules-2\\files-2.1\\cpw.mods\\securejarhandler\\0.9.54\\24b670f2c026ec9777e64a2c2126ebc8635dbe8d\\securejarhandler-0.9.54.jar;C:\\Users\\lesma\\.gradle\\caches\\modules-2\\files-2.1\\org.ow2.asm\\asm-commons\\9.1\\8b971b182eb5cf100b9e8d4119152d83e00e0fdd\\asm-commons-9.1.jar;C:\\Users\\lesma\\.gradle\\caches\\modules-2\\files-2.1\\org.ow2.asm\\asm-util\\9.1\\36464a45d871779f3383a8a9aba2b26562a86729\\asm-util-9.1.jar;C:\\Users\\lesma\\.gradle\\caches\\modules-2\\files-2.1\\org.ow2.asm\\asm-analysis\\9.1\\4f61b83b81d8b659958f4bcc48907e93ecea55a0\\asm-analysis-9.1.jar;C:\\Users\\lesma\\.gradle\\caches\\modules-2\\files-2.1\\org.ow2.asm\\asm-tree\\9.1\\c333f2a855069cb8eb17a40a3eb8b1b67755d0eb\\asm-tree-9.1.jar;C:\\Users\\lesma\\.gradle\\caches\\modules-2\\files-2.1\\org.ow2.asm\\asm\\9.1\\a99500cf6eea30535eeac6be73899d048f8d12a8\\asm-9.1.jar --add-modules ALL-MODULE-PATH --add-opens java.base/java.util.jar\u003dcpw.mods.securejarhandler --add-exports java.base/sun.security.util\u003dcpw.mods.securejarhandler --add-exports jdk.naming.dns/com.sun.jndi.dns\u003djava.naming",
+      "args": "--launchTarget forgedatauserdev --assetIndex 1.18 --assetsDir C:\\Users\\lesma\\.gradle\\caches\\forge_gradle\\assets --gameDir . --fml.forgeVersion 39.0.5 --fml.mcVersion 1.18.1 --fml.forgeGroup net.minecraftforge --fml.mcpVersion 20211210.034407 --mod mccourse --all --output C:\\Projects\\minecraft\\kaupenjoe.forge-course-118\\src\\generated\\resources --existing C:\\Projects\\minecraft\\kaupenjoe.forge-course-118\\src\\main\\resources",
+      "env": {
+        "MOD_CLASSES": "mccourse%%${workspaceFolder}\\bin\\main;mccourse%%${workspaceFolder}\\bin\\main",
+        "MCP_MAPPINGS": "parchment_2021.12.13-nightly-SNAPSHOT-1.18.1"
+      }
+    },
+    {
+      "type": "java",
+      "name": "runServer",
+      "request": "launch",
+      "mainClass": "cpw.mods.bootstraplauncher.BootstrapLauncher",
+      "projectName": "kaupenjoe.forge-course-118",
+      "cwd": "${workspaceFolder}\\run",
+      "vmArgs": "-Dforge.logging.console.level\u003ddebug -Dforge.logging.markers\u003dREGISTRIES -DlegacyClassPath.file\u003dC:\\Projects\\minecraft\\kaupenjoe.forge-course-118\\build\\classpath\\runServer_minecraftClasspath.txt -DignoreList\u003dbootstraplauncher,securejarhandler,asm-commons,asm-util,asm-analysis,asm-tree,asm,client-extra,fmlcore,javafmllanguage,mclanguage,forge- -DmergeModules\u003djna-5.8.0.jar,jna-platform-58.0.jar,java-objc-bridge-1.0.0.jar -p C:\\Users\\lesma\\.gradle\\caches\\modules-2\\files-2.1\\cpw.mods\\bootstraplauncher\\0.1.17\\899fb8e3912bb7d14a6f9611de117f77db710ec3\\bootstraplauncher-0.1.17.jar;C:\\Users\\lesma\\.gradle\\caches\\modules-2\\files-2.1\\cpw.mods\\securejarhandler\\0.9.54\\24b670f2c026ec9777e64a2c2126ebc8635dbe8d\\securejarhandler-0.9.54.jar;C:\\Users\\lesma\\.gradle\\caches\\modules-2\\files-2.1\\org.ow2.asm\\asm-commons\\9.1\\8b971b182eb5cf100b9e8d4119152d83e00e0fdd\\asm-commons-9.1.jar;C:\\Users\\lesma\\.gradle\\caches\\modules-2\\files-2.1\\org.ow2.asm\\asm-util\\9.1\\36464a45d871779f3383a8a9aba2b26562a86729\\asm-util-9.1.jar;C:\\Users\\lesma\\.gradle\\caches\\modules-2\\files-2.1\\org.ow2.asm\\asm-analysis\\9.1\\4f61b83b81d8b659958f4bcc48907e93ecea55a0\\asm-analysis-9.1.jar;C:\\Users\\lesma\\.gradle\\caches\\modules-2\\files-2.1\\org.ow2.asm\\asm-tree\\9.1\\c333f2a855069cb8eb17a40a3eb8b1b67755d0eb\\asm-tree-9.1.jar;C:\\Users\\lesma\\.gradle\\caches\\modules-2\\files-2.1\\org.ow2.asm\\asm\\9.1\\a99500cf6eea30535eeac6be73899d048f8d12a8\\asm-9.1.jar --add-modules ALL-MODULE-PATH --add-opens java.base/java.util.jar\u003dcpw.mods.securejarhandler --add-exports java.base/sun.security.util\u003dcpw.mods.securejarhandler --add-exports jdk.naming.dns/com.sun.jndi.dns\u003djava.naming",
+      "args": "--launchTarget forgeserveruserdev --gameDir . --fml.forgeVersion 39.0.5 --fml.mcVersion 1.18.1 --fml.forgeGroup net.minecraftforge --fml.mcpVersion 20211210.034407",
+      "env": {
+        "MOD_CLASSES": "mccourse%%${workspaceFolder}\\bin\\main;mccourse%%${workspaceFolder}\\bin\\main",
+        "MCP_MAPPINGS": "parchment_2021.12.13-nightly-SNAPSHOT-1.18.1"
+      }
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,31 @@
+{
+    "window.title":"kaupenjoe.forge-course-118",
+    "workbench.colorCustomizations": {
+        "terminal.ansiBlack": "#090300",
+        "terminal.ansiBlue": "#01A0E4",
+        "terminal.ansiBrightBlack": "#5C5855",
+        "terminal.ansiBrightBlue": "#01A0E4",
+        "terminal.ansiBrightCyan": "#B5E4F4",
+        "terminal.ansiBrightGreen": "#01A252",
+        "terminal.ansiBrightMagenta": "#A16A94",
+        "terminal.ansiBrightRed": "#DB2D20",
+        "terminal.ansiBrightWhite": "#F7F7F7",
+        "terminal.ansiBrightYellow": "#FDED02",
+        "terminal.ansiCyan": "#B5E4F4",
+        "terminal.ansiGreen": "#01A252",
+        "terminal.ansiMagenta": "#A16A94",
+        "terminal.ansiRed": "#DB2D20",
+        "terminal.ansiWhite": "#A5A2A2",
+        "terminal.ansiYellow": "#FDED02",
+        "terminal.background": "#090300",
+        "terminal.foreground": "#A5A2A2",
+        "terminalCursor.background": "#A5A2A2",
+        "terminalCursor.foreground": "#A5A2A2",
+        "window.activeBorder": "#00ff00",
+        "window.inactiveBorder": "#ff0000",
+        "activityBar.background": "#103411",
+        "titleBar.activeBackground": "#174918",
+        "titleBar.activeForeground": "#F5FCF6"
+    },
+    "java.configuration.updateBuildConfiguration": "automatic"
+}

--- a/failure-report.txt
+++ b/failure-report.txt
@@ -1,0 +1,57 @@
+Failing on Adam's laptop to launch mc from runClient:
+
+> Configure project :
+Java: 17.0.2 JVM: 17.0.2+8-LTS-86(Oracle Corporation) Arch: amd64
+
+> Task :runClient
+2022-07-24 11:51:58,382 main WARN Advanced terminal features are not available in this environment
+[11:51:58] [main/INFO] [cp.mo.mo.Launcher/MODLAUNCHER]: ModLauncher running: args [--launchTarget, forgeclientuserdev, --version, MOD_DEV, --assetIndex, 1.19, --assetsDir, C:\Users\thing\.gradle\caches\forge_gradle\assets, --gameDir, ., --fml.forgeVersion, 41.0.38, --fml.mcVersion, 1.19, --fml.forgeGroup, net.minecraftforge, --fml.mcpVersion, 20220607.102129]
+[11:51:58] [main/INFO] [cp.mo.mo.Launcher/MODLAUNCHER]: ModLauncher 10.0.8+10.0.8+main.0ef7e830 starting: java version 17.0.2 by Oracle Corporation; OS Windows 10 arch amd64 version 10.0
+[11:51:58] [main/DEBUG] [cp.mo.mo.LaunchServiceHandler/MODLAUNCHER]: Found launch services [fmlclientdev,forgeclient,minecraft,forgegametestserverdev,fmlserveruserdev,fmlclient,fmldatauserdev,forgeserverdev,forgeserveruserdev,forgeclientdev,forgeclientuserdev,forgeserver,forgedatadev,fmlserver,fmlclientuserdev,fmlserverdev,forgedatauserdev,testharness,forgegametestserveruserdev]
+[11:51:58] [main/DEBUG] [cp.mo.mo.NameMappingServiceHandler/MODLAUNCHER]: Found naming services : [srgtomcp]
+<============-> 92% EXECUTING [4s]
+> :runClient
+Exception in thread "main" java.lang.IllegalAccessError: class cpw.mods.modlauncher.util.ServiceLoaderUtils (in module cpw.mods.modlauncher) cannot access class cpw.mods.niofs.union.UnionFileSystem (in module cpw.mods.securejarhandler) because module cpw.mods.securejarhandler does not export cpw.mods.niofs.union to module cpw.mods.modlauncher
+        at MC-BOOTSTRAP/cpw.mods.modlauncher@10.0.8/cpw.mods.modlauncher.util.ServiceLoaderUtils.lambda$fileNameFor$2(ServiceLoaderUtils.java:52)
+        at java.base/java.util.Optional.map(Optional.java:260)
+        at MC-BOOTSTRAP/cpw.mods.modlauncher@10.0.8/cpw.mods.modlauncher.util.ServiceLoaderUtils.fileNameFor(ServiceLoaderUtils.java:52)
+        at MC-BOOTSTRAP/cpw.mods.modlauncher@10.0.8/cpw.mods.modlauncher.LaunchPluginHandler.lambda$new$2(LaunchPluginHandler.java:50)
+        at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
+        at java.base/java.util.HashMap$EntrySpliterator.forEachRemaining(HashMap.java:1850)
+        at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
+        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
+        at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:575)
+        at java.base/java.util.stream.AbstractPipeline.evaluateToArrayNode(AbstractPipeline.java:260)
+        at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:616)
+        at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:622)
+        at java.base/java.util.stream.ReferencePipeline.toList(ReferencePipeline.java:627)
+        at MC-BOOTSTRAP/cpw.mods.modlauncher@10.0.8/cpw.mods.modlauncher.LaunchPluginHandler.<init>(LaunchPluginHandler.java:51)
+        at MC-BOOTSTRAP/cpw.mods.modlauncher@10.0.8/cpw.mods.modlauncher.Launcher.<init>(Launcher.java:64)
+        at MC-BOOTSTRAP/cpw.mods.modlauncher@10.0.8/cpw.mods.modlauncher.Launcher.main(Launcher.java:77)
+        at MC-BOOTSTRAP/cpw.mods.modlauncher@10.0.8/cpw.mods.modlauncher.BootstrapLaunchConsumer.accept(BootstrapLaunchConsumer.java:26)
+        at MC-BOOTSTRAP/cpw.mods.modlauncher@10.0.8/cpw.mods.modlauncher.BootstrapLaunchConsumer.accept(BootstrapLaunchConsumer.java:23)
+        at cpw.mods.bootstraplauncher@1.1.0/cpw.mods.bootstraplauncher.BootstrapLauncher.main(BootstrapLauncher.java:155)
+
+FAILURE: Build failed with an exception.
+
+* What went wrong:
+Execution failed for task ':runClient'.
+> Process 'command 'C:\Program Files\Java\jdk-17.0.2\bin\java.exe'' finished with non-zero exit value 1
+
+* Try:
+> Run with --stacktrace option to get the stack trace.
+> Run with --info or --debug option to get more log output.
+> Run with --scan to get full insights.
+
+* Get more help at https://help.gradle.org
+
+> Task :runClient FAILED
+
+Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.
+
+You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.
+
+See https://docs.gradle.org/7.3/userguide/command_line_interface.html#sec:command_line_warnings
+10 actionable tasks: 3 executed, 7 up-to-date
+Could not execute build using connection to Gradle distribution 'https://services.gradle.org/distributions/gradle-7.3-bin.zip'.
+ *  The terminal process terminated with exit code: 1.


### PR DESCRIPTION
Some sort of version incoherence between FML, Minecraft, JDK?
- After setting up the environment, I do a `runClient`.
- Works fine on my Windows 11 machine.  But on Adam's Windows 10 machine we get [this failure report](https://github.com/Stabledog/Forge-Course-118/blob/work/failure-report.txt, a.k.a. https://paste.ofcode.org/Rac8fCNzsABx8ZUAqwWJDd)
- Discord inquiry: https://discord.com/channels/836324368803430400/924032113437716550/1000847436799021127